### PR TITLE
解决cocos creator 1.6正式版，断网会崩的问题。

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,25 @@ Cocos Creator客户端Pomelo插件,Cocos Creator 1.5已经测试可用。
 
 # 使用方法
 将pomelo-creator-client.js文件导入Cocos Creator的工程目录中，并且在属性检查器中设置为导入为插件
+非首次初始化pomelo的时候，一定要等上次的disconnect后再初始化，
+需要断线重连的，要记得init的时候，传入reconnect参数
+
+# 示例
+pomelo.init({
+    host : host1,
+    port : port1
+}, function () {
+    var route = 'gate.gateHandler.queryEntry';
+    pomelo.request(route, {
+    }, function () {
+        pomelo.disconnect(function () {
+            pomelo.init({
+                host : host2,
+                port : port2,
+                reconnect : true
+            }, function () {
+            })
+        });
+    })
+    
+});

--- a/README.md
+++ b/README.md
@@ -3,7 +3,9 @@ Cocos Creator客户端Pomelo插件,Cocos Creator 1.5已经测试可用。
 
 # 使用方法
 将pomelo-creator-client.js文件导入Cocos Creator的工程目录中，并且在属性检查器中设置为导入为插件
+
 非首次初始化pomelo的时候，一定要等上次的disconnect后再初始化
+
 需要断线重连的，要记得init的时候，传入reconnect参数
 
 # 示例

--- a/README.md
+++ b/README.md
@@ -3,10 +3,11 @@ Cocos Creator客户端Pomelo插件,Cocos Creator 1.5已经测试可用。
 
 # 使用方法
 将pomelo-creator-client.js文件导入Cocos Creator的工程目录中，并且在属性检查器中设置为导入为插件
-非首次初始化pomelo的时候，一定要等上次的disconnect后再初始化，
+非首次初始化pomelo的时候，一定要等上次的disconnect后再初始化
 需要断线重连的，要记得init的时候，传入reconnect参数
 
 # 示例
+```
 pomelo.init({
     host : host1,
     port : port1
@@ -25,3 +26,4 @@ pomelo.init({
     })
     
 });
+```

--- a/pomelo-creator-client.js
+++ b/pomelo-creator-client.js
@@ -1157,6 +1157,7 @@
   var Message = Protocol.Message;
   var EventEmitter = window.EventEmitter;
   var rsa = window.rsa;
+  var disconnectCb = null;
 
   if(typeof(window) != "undefined" && typeof(sys) != 'undefined' && sys.localStorage) {
     window.localStorage = sys.localStorage;
@@ -1342,6 +1343,9 @@
         }, reconnectionDelay);
         reconnectionDelay *= 2;
       }
+      socket = null;
+      disconnectCb && disconnectCb();
+      disconnectCb = null;
     };
     socket = new WebSocket(url);
     socket.binaryType = 'arraybuffer';
@@ -1351,7 +1355,8 @@
     socket.onclose = onclose;
   };
 
-  pomelo.disconnect = function() {
+  pomelo.disconnect = function(cb) {
+    disconnectCb = cb;
     if(socket) {
       if(socket.disconnect) socket.disconnect();
       if(socket.close) socket.close();
@@ -1417,7 +1422,9 @@
   };
 
   var send = function(packet) {
-    socket.send(packet.buffer);
+    if (socket !== null) {
+        socket.send(packet.buffer);
+    }
   };
 
   var handler = {};


### PR DESCRIPTION
pomelo.disconnect支持传入回掉。
非首次初始化pomelo的时候，一定要等上次的disconnect后再初始化，
需要断线重连的，要记得init的时候，传入reconnect参数
示例：
pomelo.init({
    host : host1,
    port : port1
}, function () {
    var route = 'gate.gateHandler.queryEntry';
    pomelo.request(route, {
    }, function () {
        pomelo.disconnect(function () {
            pomelo.init({
                host : host2,
                port : port2,
                reconnect : true
            }, function () {
            })
        });
    })

});